### PR TITLE
adding transportability and impact

### DIFF
--- a/ProposalStrategySummary.tex
+++ b/ProposalStrategySummary.tex
@@ -96,10 +96,14 @@
 \end{itemize}
 
 %--------------------------------------------------------------------------------
-\noindent \textbf{transportatbility and impact}
-This is written with the perspective of beefing up our dissemination section.
+\vspace{2em}
+\noindent \textbf{Transportability and Impact}
 
-Features that make projects transportable:
+\vspace{1em}
+\noindent This is written with the perspective of beefing up our dissemination section.
+
+\vspace{1em}
+\noindent Features that make projects transportable:
 \begin{itemize}
 \item built in flexibility (we cover this well)
 \item identification of how the approach can be used with other teaching
@@ -107,14 +111,15 @@ Features that make projects transportable:
   well)
 \item clearly state learning goals and objectives (addressed elsewhere)
 \item address a common need (addressed elsewhere)
-\item minimize speciation equipment needs and implementation costs (this is
+\item minimize specialized equipment needs and implementation costs (this is
   pretty easy for us to address)
 \item collect convincing evaluation data (discussed elsewhere)
 \item provide options for gradual scale up (natural feature of the bootcamps)
 \item involve faculty at other sites (done)
 \end{itemize}
 
-To make materials that might be adopted by other faculty, the adaptability
+\vspace{1em}
+\noindent To make materials that might be adopted by other faculty, the adaptability
 needs to be made clear. 
 \begin{itemize}
 \item materials are easily modifiable (check)
@@ -131,9 +136,10 @@ needs to be made clear.
   \end{itemize}
 \end{itemize}
 
-Things that make a project transformative (that apply to us):
+\vspace{1em}
+\noindent Things that make a project transformative (that apply to us):
 \begin{itemize}
-\item adresses a problem that the community judges to be significant and
+\item addresses a problem that the community judges to be significant and
   important.
 \item develops effective products, curriculum materials, etc.
 \item has transportable elements that other educators could adopt or adapt.
@@ -146,12 +152,14 @@ Things that make a project transformative (that apply to us):
 
 
 %------------------------------------------------------------------------------
+\vspace{2em}
 \noindent \textbf{Broader Impacts}
 
-Categories of desired BI outcomes
+\vspace{1em}
+\noindent Categories of desired BI outcomes
 \begin{itemize}
 \item full participation of women, persons with disabilities, and
-  underrepresented minorities in STEM
+  under-represented minorities in STEM
 \item improved STEM education and educator development at any level
 \item increased public scientific literacy and engagement
 \item improved well-being of individuals in society
@@ -162,16 +170,19 @@ Categories of desired BI outcomes
 \item enhanced infrastructure for research and education
 \end{itemize}
 
-Intellectual Merit and Broader Impacts activities should be a whole and make
+\vspace{1em}
+\noindent Intellectual Merit and Broader Impacts activities should be a whole and make
 sense. Discussion of publications, etc.\ should also be here. Need to have an
 evaluation plan associated with the BI. Outreach activities? Dissemination
 needs to be active.
 
-Include rational about why that underrepresented group was selected and talk
+\vspace{1em}
+\noindent Include rational about why that under-represented group was selected and talk
 about how your approach makes sense (couch in research if possible). Think
 through issues about access, e.g., off-hours activities can limit participation.
 
-Evaluation plan for broadening participation strategies is needed.
+\vspace{1em}
+\noindent Evaluation plan for broadening participation strategies is needed.
 
 \vspace{2em}
 \noindent ----- Aside from the CommonGuidelines document -----\\

--- a/ProposalStrategySummary.tex
+++ b/ProposalStrategySummary.tex
@@ -7,7 +7,7 @@
 \begin{document}
 
 \begin{center}
-{Proposal Strategies, NSF IWBW Summary}
+{NSF IWBW Summaries}
 \end{center}
 
 \setlength{\unitlength}{1in}
@@ -18,6 +18,8 @@
 \renewcommand{\arraystretch}{2}
 %\vspace{2em}
 %\noindent \underline{Workshop goal}: enhance the participants' knowledge of essential elements of an educational proposal, or education component of more general proposal, and their understanding of strategies for developing more effective proposals. 
+
+\noindent \textbf{Proposal Strategies}
 
 \vspace{2em}
 \noindent Competitive proposals have
@@ -92,6 +94,84 @@
 \item dissemination plan
 \item evaluation plan
 \end{itemize}
+
+%--------------------------------------------------------------------------------
+\noindent \textbf{transportatbility and impact}
+This is written with the perspective of beefing up our dissemination section.
+
+Features that make projects transportable:
+\begin{itemize}
+\item built in flexibility (we cover this well)
+\item identification of how the approach can be used with other teaching
+  styles, other models, other courses, or other disciplines (we cover this
+  well)
+\item clearly state learning goals and objectives (addressed elsewhere)
+\item address a common need (addressed elsewhere)
+\item minimize speciation equipment needs and implementation costs (this is
+  pretty easy for us to address)
+\item collect convincing evaluation data (discussed elsewhere)
+\item provide options for gradual scale up (natural feature of the bootcamps)
+\item involve faculty at other sites (done)
+\end{itemize}
+
+To make materials that might be adopted by other faculty, the adaptability
+needs to be made clear. 
+\begin{itemize}
+\item materials are easily modifiable (check)
+\item clearly explain how these materials are transferable (easy to do in our
+  final products)
+\item give suggested modifications for different situations (similar to
+  above)
+\item Encouraging, facilitation, and enabling others 
+  \begin{itemize}
+  \item materials need to be known about, available, and support for using
+    them should be given. 
+  \item there should be extensive reach and an ability for people to
+    contribute back.
+  \end{itemize}
+\end{itemize}
+
+Things that make a project transformative (that apply to us):
+\begin{itemize}
+\item adresses a problem that the community judges to be significant and
+  important.
+\item develops effective products, curriculum materials, etc.
+\item has transportable elements that other educators could adopt or adapt.
+\item is relatively easy and inexpensive to implement.
+\item has a plan to engage and enable the appropriate academic community.
+\item makes strategic use of existing dissemination practices and introduces
+  new ones.
+\item has an extensive evaluation component.
+\end{itemize}
+
+
+%------------------------------------------------------------------------------
+\noindent \textbf{Broader Impacts}
+
+Categories of desired BI outcomes
+\begin{itemize}
+\item full participation of women, persons with disabilities, and
+  underrepresented minorities in STEM
+\item improved STEM education and educator development at any level
+\item increased public scientific literacy and engagement
+\item improved well-being of individuals in society
+\item development of a diverse, globally competitive STEM workforce
+\item increased partnerships between academia, industry, and others
+\item improved national security
+\item increased economic competitiveness of the United States
+\item enhanced infrastructure for research and education
+\end{itemize}
+
+Intellectual Merit and Broader Impacts activities should be a whole and make
+sense. Discussion of publications, etc.\ should also be here. Need to have an
+evaluation plan associated with the BI. Outreach activities? Dissemination
+needs to be active.
+
+Include rational about why that underrepresented group was selected and talk
+about how your approach makes sense (couch in research if possible). Think
+through issues about access, e.g., off-hours activities can limit participation.
+
+Evaluation plan for broadening participation strategies is needed.
 
 \vspace{2em}
 \noindent ----- Aside from the CommonGuidelines document -----\\

--- a/dissemination_plan.tex
+++ b/dissemination_plan.tex
@@ -1,0 +1,6 @@
+\documentclass[11pt]{article}
+\begin{document}
+
+\section{Dissemination Plan}
+
+\end{document}

--- a/dissemination_plan.tex
+++ b/dissemination_plan.tex
@@ -1,6 +1,0 @@
-\documentclass[11pt]{article}
-\begin{document}
-
-\section{Dissemination Plan}
-
-\end{document}

--- a/proposal.tex
+++ b/proposal.tex
@@ -287,6 +287,15 @@ skills and outlook, etc.
 
 \subsection{Curriculum Development and Dissemination}
 
+- presentations, articles, and material availability plan
+- advertising plan
+- our materials are flexible and can be easily adopted by any other faculty
+- adapting materials is low cost and requires no special equipment
+- it is easy to scale this to any size and application
+- the materials are already used globally, and we have an extensive set of
+support people to help those who use the materials
+- other can contribute back to the resources to improve them organically
+
 We will employ one instructional designer part-time during each of the
 study's first four years to create new material, and to improve
 existing material based on feedback from workshop participants and the

--- a/proposal.tex
+++ b/proposal.tex
@@ -6,9 +6,9 @@
 }
 
 \author{
-  Rachel Slaybaugh, Kaitlin Thaney, Lorena Barba, C. Titus Brown, and Paul Wilson\\
-  with\\
-  Scott Collins, Ethan White, Tracy Teal, and Greg Wilson
+  Rachel Slaybaugh, Kaitlin Thaney, Lorena Barba, C. Titus Brown,\\   
+  and Paul Wilson\\ 
+  with Scott Collins, Ethan White, Tracy Teal, and Greg Wilson
 }
 
 \newcommand{\fixme}[2]{FIXME (#1): {#2}}
@@ -16,12 +16,12 @@
 \begin{document}
 \maketitle
 \pagebreak
-
-\section{Summary}
-
-FIXME: one-page summary
-
-\pagebreak
+% This is submitted as a separate section in Fast Lane
+%\section{Summary}
+%
+%FIXME: one-page summary
+%
+%\pagebreak
 
 \section{The Problem}
 
@@ -45,7 +45,7 @@ pre-requisite skills in the general STEM research community.
 Since the mid-1980s (at least), proponents of computational science
 have taken an ``if we build it, they will come'' approach to this
 problem.  It is clear now, though, that learning-by-osmosis has not
-worked, and is unlikely to in future for several reasons:
+worked, and is unlikely to in the future for several reasons:
 
 \begin{enumerate}
 
@@ -210,19 +210,19 @@ The sections below detail the specific activities we will undertake.
 We will run two-day workshops at a steadily increasing number of sites
 each year for four years, timed to coincide with the start of the
 summer REU influx.  Each workshop will be offered to a minimum of 40
-learners per site (giving is a target study population of 1440
-students by year 4).  The content will be tailored to meet local
-needs, but will be based on what is being used at that time by
-Software Carpentry and affiliated educational efforts.  All of the
+learners per site (giving us a target study population of 1440
+students by year 4).  All of the
 workshop instructors will have been trained and certified by Software
 Carpentry, and will have had prior experience teaching this material.
+The content will be tailored to meet local
+needs, but will be based on what is being used at that time by
+Software Carpentry and affiliated educational efforts.  By design, it is straightforward to adapt workshop materials and contribute changes back to the Software Carpentry organization.  These features enhance the portability and flexibility of the workshops, and increase the likelihood of wide dissemination beyond this project.  
 
 The six home sites for investigators named in this proposal (Michigan
 State U., Utah State U., George Washington U., U.\ New Mexico, UC
 Berkeley, and U.\ Wisconsin - Madison) will run workshops in each of
 those years.  Two other NSF REU sites will be added each year,
-increasing the total to 12 sites by year 4, to increase the size of
-our study population.
+increasing the total to 12 sites by year 4, which increases the size of our study population.
 
 In order to increase the diversity of the study population, we will
 additionally run at least one workshop in each of years 1-4 that is
@@ -253,9 +253,10 @@ will employ one full-time researcher for five years to monitor
 undergraduate participants in these workshops, participants in a
 subset of our regular (graduate-level) workshops, and non-participants
 (as a control population) for comparison purposes.  This researcher
-will also explore ways in which our engagement with students changes
+will also investigate whether the outcomes among
+underrepresented minorities and women differ from non-underrepresented minorities and men, respectively. Finally, the employed research will explore ways in which our engagement with students changes
 the outlook and work practices of their peers and faculty supervisors,
-i.e., whether there is knowledge transfer sideways and upward.
+i.e., whether there is knowledge transfer sideways and upward. 
 
 As with our work to date, assessment will use both qualitative and
 quantitative techniques.  On the qualitative side, we will conduct a
@@ -264,7 +265,7 @@ attitudes, aspirations, and activities change.  Quantitatively, we
 will measure uptake of key tools such as version control as a proxy
 for adoption of related practices, as well as exploring more
 traditional measures of research success such as progression to
-graduate school and publication/citation rates.
+graduate school and publication/citation rates.  
 
 \subsection{Community Building}
 
@@ -287,15 +288,6 @@ skills and outlook, etc.
 
 \subsection{Curriculum Development and Dissemination}
 
-- presentations, articles, and material availability plan
-- advertising plan
-- our materials are flexible and can be easily adopted by any other faculty
-- adapting materials is low cost and requires no special equipment
-- it is easy to scale this to any size and application
-- the materials are already used globally, and we have an extensive set of
-support people to help those who use the materials
-- other can contribute back to the resources to improve them organically
-
 We will employ one instructional designer part-time during each of the
 study's first four years to create new material, and to improve
 existing material based on feedback from workshop participants and the
@@ -312,7 +304,27 @@ freely available under the Creative Commons - Attribution (CC-BY)
 license.  The instructional designer will work with the Mozilla
 Science Lab and affiliated groups to share these materials, and the
 results of our studies of the program's impact, through science
-education journals, conferences, and other channels.
+education journals, conferences, and other channels. Specifically, we plan to publish articles in the following journals 
+\begin{itemize}
+\item Journal of Computers in Mathematics and Science Teaching, and
+%
+\item Physics Education,
+\end{itemize}
+%
+and present papers at the following conferences
+\begin{itemize}
+\item  the Special Interest Group on Computer Science Education (SIGCSE) of the Association for Computing Machinery, Inc. (ACM),
+%
+\item the International Conference on Physics Education (ICPE),
+%
+\item the Association for Biology Laboratory Education (ABLE),
+%
+\item the Society for Industrial and Applied Mathematics (SIAM), and
+%
+\item the American Nuclear Society (ANS).
+\end{itemize}
+
+The dissemination of this project's curriculum has strong potential to be high. Workshop materials are all open access and flexible, thus they can be readily adopted by others. Adapting workshop materials is low cost and does not require special equipment. Workshop materials are structured such that they can scale to the size and application of interest to a particular group. The Software Carpentry infrastructure provides support in the form of materials and people. Anyone using workshop materials can directly contribute changes and feedback, which both increases buy-in and improves the materials organically. And finally, local chapters of The Hacker Within create a natural ecosystem of support for workshop participants, their peers, and faculty. 
 
 \section{Broader Impact}
 
@@ -381,7 +393,7 @@ backgrounds. This means that they do not have a mentor to teach them
 about good computational practice in research. In addition, they do
 not have someone to discuss computational careers with, thus limiting
 their exposure to career paths outside of academia. Because the
-faculty mentors will have strong computational backgrounds, themselves
+faculty mentors will have strong computational backgrounds themselves,
 they can fill this void for computationally-minded students.
 
 \section{Data Management Plan}


### PR DESCRIPTION
updated the proposal strategies to include comments from all three webinars.

removed the summary section since it needs to be submitted separately (though I'm not sure how we need to handle section numbering with this change). This will also apply to the Data Management Plan and some additional sections we haven't added yet. 

added more impact and transportability material. More may be required - I'm not sure how we are on length. If I switch this to the proposalnsf style it's only starting onto page 7.
