### PR TITLE
Add condos

### DIFF
--- a/proposal.tex
+++ b/proposal.tex
@@ -311,7 +311,14 @@ Utah State University) will run workshops in each of those years.
 Other sites will be added each year, increasing the total to 15 in
 year 5, which increases the size of our study population.  We will
 focus expansion on NSF REU sites \cite{nsfreu}, but as detailed in the
-next section, we will also offer some workshops to other communities.
+next section, we will also offer some workshops to other communities.  
+
+One set of possible sites are those campuses included in the ``Condo of
+Condos'' consortium, recently recommended for funding by the National Science
+Foundation.  The Software Carpentry workshops proposed here will be valuable
+to that consortium in meeting its goals of increasing the number and diversity
+of researchers using advanced cyberinfrastructure, and of developing data
+science practitioners.
 
 While there is considerable scope for customizing
 workshops to accommodate learners' prior experience and
@@ -716,6 +723,23 @@ Within have since become instructors with Software Carpentry, and a
 new generation of THW graduate students has begun to emerge in their
 place. In 2013, new branches of THW were initiated at the University
 of Melbourne and the University of California - Berkeley.
+
+\subsection{Condo of Condos}
+\label{sec:CofC}
+
+The ``Condo of Condos'' consortium, led by Clemson University and including
+the University of Wisconsin -- Madison and four other campuses during its
+pilot phase, has recently been recommended for funding by the National Science
+Foundation.  The consortium's primary task is to build a network of advanced
+cyberinfrastructure research and education facilitors (ACI-REFs), with goals
+that include increasing the diversity of researchers using advanced
+cyberinfrastructure on each campus and developing data science practitioners.
+The Software Carpentry workshops being designed under this proposal will serve
+those goals directly.  As an investigator on both that project and this
+proposal, Prof.\ P.\ Wilson will engage the network of ACI-REFs to share this
+curriculum with both the initial consortium institutions, and any institutions
+who are able to join in the future.
+
 
 \section{Broader Impact}
 

--- a/proposal.tex
+++ b/proposal.tex
@@ -110,7 +110,7 @@ This project will train STEM undergraduates in these skills, and
 assess the impact of that training on their productivity and career
 paths.  We will do this by running software skills workshops for
 undergraduates likely to go on to graduate school, and by tracking
-their alumni of these workshops over several subsequent years both to
+the alumni of these workshops over several subsequent years both to
 improve the training itself and to encourage wider adoption of our
 model.
 
@@ -573,13 +573,13 @@ assisted by Dr.\ Huff, who will manage and coordinate the graduate
 student assistants at each site.  Dr.\ Huff will also be responsible
 for organizing the workshops aimed at female students.
 
-Profs.\ Barba, Brown, White, and Wilson will be responsible for
+Profs.\ Barba, Brown, White, and P.\ Wilson will be responsible for
 coordinating workshops and for recruiting and supervising the graduate
 student assistant at their respective institutions.
 
-Dr.\ Wilson and the half-time instructional designer hired by this
+Dr.\ G.\ Wilson and the half-time instructional designer hired by this
 project will be responsible for preparation and publication of
-learning materials.  Dr.\ Wilson will also provide instructional
+learning materials.  Dr.\ G.\ Wilson will also provide instructional
 training for the graduate student assistants and other participants in
 the project on an ongoing basis, and will be responsible for
 organizing the workshops aimed at students from underrepresented


### PR DESCRIPTION
A couple of minor edits.  In particular, I added first initials for @gvwilson and myself to disambiguate the 2 Wilsons.

I've added reference to the Condo of Condos consortium in 2 places:
- briefly in the description of the workshops
- a little more detail in the related work section

Couldn't really find a good place in the curriculum dissemination section.
